### PR TITLE
chore(deps): update tombursch/kitchenowl docker tag to v0.7.4

### DIFF
--- a/apps/kitchenowl/config.json
+++ b/apps/kitchenowl/config.json
@@ -8,14 +8,18 @@
   "short_desc": "KitchenOwl",
   "author": "tombursch",
   "port": 8828,
-  "categories": [ "featured" ],
+  "categories": [
+    "featured"
+  ],
   "description": "A smart grocery list and recipe manager.",
-  "tipi_version": 2,
-  "version": "v0.6.15",
+  "tipi_version": 3,
+  "version": "v0.7.4",
   "source": "https://github.com/tombursch/kitchenowl",
-  "supported_architectures": [ "amd64" ],
+  "supported_architectures": [
+    "amd64"
+  ],
   "created_at": 1731806734301,
-  "updated_at": 1731806734302,
+  "updated_at": 1764016726849,
   "form_fields": [
     {
       "type": "text",

--- a/apps/kitchenowl/docker-compose.json
+++ b/apps/kitchenowl/docker-compose.json
@@ -4,7 +4,7 @@
   "services": [
     {
       "name": "kitchenowl",
-      "image": "tombursch/kitchenowl:v0.6.15",
+      "image": "tombursch/kitchenowl:v0.7.4",
       "isMain": true,
       "internalPort": 8080,
       "environment": [


### PR DESCRIPTION
This pull request updates KitchenOwl to the latest version and ensures compatibility with the latest Tipi platform. The main changes are version upgrades in both configuration and deployment files.

Version and compatibility updates:

* Updated `version` to `v0.7.4` and `tipi_version` to `3` in `apps/kitchenowl/config.json`, reflecting the latest release and platform compatibility.
* Changed Docker image in `apps/kitchenowl/docker-compose.json` to use `tombursch/kitchenowl:v0.7.4`, ensuring the deployment uses the newest version.

Other minor updates:

* Updated the `updated_at` timestamp in `apps/kitchenowl/config.json` to reflect the new changes.